### PR TITLE
Allow keyboard pattern /keyboard|Keyboard|KEYBOARD/

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,10 @@ Metrics/LineLength:
   Max: 100
   Exclude:
     - "fusuma-plugin-*.gemspec"
+
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ swipe:
       sendkey: "LEFTCTRL+W" # close tab
 ```
 
+
+### Specify keyboard by device name
+
+If you got following error message, try to set your keyboard name to `plugin.executors.sendkey_executor.device_name` on config.yml
+
+```shell
+$ fusuma-sendkey -l
+sendkey: Keyboard: /keyboard|Keyboard|KEYBOARD/ is not found
+```
+
+Set the following options to recognize keyboard only for the specified keyboard device.
+Open `~/.config/fusuma/config.yml` and add the following code at the bottom.
+
+```yaml
+plugin:
+  executors:
+    sendkey_executor:
+      device_name: 'YOUR KEYBOARD NAME'
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/iberianpig/fusuma-plugin-sendkey. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/fusuma/plugin/sendkey/device.rb
+++ b/lib/fusuma/plugin/sendkey/device.rb
@@ -10,7 +10,7 @@ module Fusuma
         end
 
         def path
-          raise 'Keyboard is not found' if @evdev.nil?
+          raise 'Device path is not found' if @evdev.nil?
 
           @path ||= @evdev.file.path
         end

--- a/lib/fusuma/plugin/sendkey/keyboard.rb
+++ b/lib/fusuma/plugin/sendkey/keyboard.rb
@@ -10,19 +10,18 @@ module Fusuma
     module Sendkey
       # Emulate Keyboard
       class Keyboard
-        def initialize(name_pattern: nil)
-          name_pattern ||= 'keyboard'
+        def initialize(name_pattern: 'keyboard|Keyboard|KEYBOARD')
           device = find_device(name_pattern: name_pattern)
 
           if device.nil?
-            warn "sendkey: Keyboard /#{name_pattern}/ is not found"
+            warn "sendkey: Keyboard: /#{name_pattern}/ is not found"
             exit(1)
           end
 
           @device = Device.new(path: "/dev/input/#{device.id}")
         end
 
-        attr_writer :device
+        attr_reader :device
 
         # @param param [String]
         def type(param:)

--- a/spec/fusuma/plugin/sendkey/keyboard_spec.rb
+++ b/spec/fusuma/plugin/sendkey/keyboard_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require './lib/fusuma/plugin/sendkey/keyboard'
+
+module Fusuma
+  module Plugin
+    module Sendkey
+      RSpec.describe Keyboard do
+        describe '#new' do
+          context 'keyboard is found' do
+            before do
+              dummy_keyboard = Fusuma::Device.new(name: 'dummy keyboard')
+              allow_any_instance_of(Sendkey::Keyboard)
+                .to receive(:find_device)
+                .and_return(dummy_keyboard)
+              allow(Sendkey::Device).to receive(:new).and_return('dummy')
+            end
+
+            it 'should not raise error' do
+              expect { Keyboard.new }.not_to raise_error
+            end
+          end
+
+          context 'keyboard is not found' do
+            before do
+              allow_any_instance_of(Sendkey::Keyboard)
+                .to receive(:find_device)
+                .and_return(nil)
+            end
+
+            it 'should not raise error' do
+              expect { Keyboard.new }.to raise_error SystemExit
+            end
+          end
+
+          context 'detected device name is Keyboard (Capitarized)' do
+            before do
+              other_device = Fusuma::Device.new(name: 'Keyboard', id: 'dummy')
+
+              allow_any_instance_of(Sendkey::Keyboard)
+                .to receive(:find_device)
+                .and_return(other_device)
+              allow(Sendkey::Device).to receive(:new).and_return('dummy')
+            end
+
+            it 'should not raise error' do
+              expect { Keyboard.new }.not_to raise_error
+            end
+          end
+
+          context 'detected device name is KEYBOARD (Upper case)' do
+            before do
+              other_device = Fusuma::Device.new(name: 'KEYBOARD', id: 'dummy')
+              allow_any_instance_of(Sendkey::Keyboard)
+                .to receive(:find_device)
+                .and_return(other_device)
+              allow(Sendkey::Device).to receive(:new).and_return('dummy')
+            end
+
+            it 'should not raise error' do
+              expect { Keyboard.new }.not_to raise_error
+            end
+          end
+
+          context 'given name pattern' do
+            before do
+              specified_device = Fusuma::Device.new(
+                name: 'Awesome KEY/BOARD input device',
+                id: 'dummy'
+              )
+              allow(Fusuma::Device).to receive(:all).and_return([specified_device])
+              allow(Sendkey::Device).to receive(:new).and_return('dummy')
+            end
+
+            it 'should not raise error' do
+              expect { Keyboard.new(name_pattern: 'Awesome KEY/BOARD') }.not_to raise_error
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
ref: https://github.com/iberianpig/fusuma-plugin-sendkey/issues/5#issuecomment-657219534

The default name pattern is changed to `/keyboard|Keyboard|KEYBOARD/`.
Old pattern wasn't a match before, this pattern will match to `Apple Inc. Apple Internal Keyboard / Trackpad`.