### PR TITLE
fix for `cannot load such file -- revdev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ To install gems system-wide, see any of the methods listed on [Arch Wiki](https:
 
 
 ```sh
+$ sudo gem install revdev
+$ sudo gem install bundler
 $ sudo gem install fusuma-plugin-sendkey
 ```
 


### PR DESCRIPTION
Fixes #18 

This fixes the error '/usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require': cannot load such file -- revdev (LoadError)'