### PR TITLE
Add support for keypress parameter in sendkey executor

### DIFF
--- a/lib/fusuma/plugin/executors/sendkey_executor.rb
+++ b/lib/fusuma/plugin/executors/sendkey_executor.rb
@@ -34,7 +34,10 @@ module Fusuma
         # @param event [Event]
         # @return [nil]
         def _execute(event)
-          keyboard.type(param: search_param(event))
+          keyboard.type(
+            param: search_param(event),
+            keep: search_keypress(event)
+          )
         end
 
         # check executable
@@ -58,6 +61,15 @@ module Fusuma
         def search_param(event)
           index = Config::Index.new([*event.record.index.keys, :sendkey])
           Config.search(index)
+        end
+
+        # @param event [Event]
+        # @return [String]
+        def search_keypress(event)
+          keys = event.record.index.keys
+          keypress_index = keys.find_index { |k| k.symbol == :keypress }
+          code = keypress_index && keys[keypress_index + 1].symbol
+          code.to_s
         end
       end
     end

--- a/lib/fusuma/plugin/sendkey/keyboard.rb
+++ b/lib/fusuma/plugin/sendkey/keyboard.rb
@@ -41,14 +41,18 @@ module Fusuma
         end
 
         # @param param [String]
-        def type(param:)
+        # @param keep [String]
+        def type(param:, keep: "")
           return unless param.is_a?(String)
 
           param_keycodes = param_to_keycodes(param)
+          keep_keycodes = param_to_keycodes(keep)
+
+          type_keycodes = param_keycodes - keep_keycodes
           # release other modifier keys before sending key
           clear_modifiers(MODIFIER_KEY_CODES - param_keycodes)
-          param_keycodes.each { |keycode| keydown(keycode) && key_sync }
-          param_keycodes.reverse_each { |keycode| keyup(keycode) && key_sync }
+          type_keycodes.each { |keycode| keydown(keycode) && key_sync }
+          type_keycodes.reverse_each { |keycode| keyup(keycode) && key_sync }
         end
 
         def keydown(keycode)

--- a/spec/fusuma/plugin/executors/sendkey_executor_spec.rb
+++ b/spec/fusuma/plugin/executors/sendkey_executor_spec.rb
@@ -18,6 +18,9 @@ module Fusuma
               1:
                 direction:
                   sendkey: KEY_CODE
+                  keypress:
+                    LEFTSHIFT:
+                      sendkey: KEY_CODE_WITH_KEYPRESS
 
             plugin:
               executors:
@@ -34,7 +37,7 @@ module Fusuma
           index = Config::Index.new([:dummy, 1, :direction])
           record = Events::Records::IndexRecord.new(index: index)
           @event = Events::Event.new(tag: "dummy_detector", record: record)
-          @executor = described_class.new
+          @executor = SendkeyExecutor.new
 
           @keyboard = instance_double(Sendkey::Keyboard)
 
@@ -59,8 +62,25 @@ module Fusuma
         describe "#_execute" do
           it "send KEY_CODE message to keybard" do
             allow(@executor).to receive(:search_param).with(@event).and_return("KEY_CODE")
-            expect(@keyboard).to receive(:type).with(param: "KEY_CODE")
+            allow(@executor).to receive(:search_keypress).with(@event).and_return(nil)
+            expect(@keyboard).to receive(:type).with(param: "KEY_CODE", keep: nil)
             @executor._execute(@event)
+          end
+
+          context "with keypress" do
+            before do
+              index_with_keypress = Config::Index.new(
+                [:dummy, 1, :direction, :keypress, :LEFTSHIFT]
+              )
+              record = Events::Records::IndexRecord.new(index: index_with_keypress)
+              @event = Events::Event.new(tag: "dummy_detector", record: record)
+            end
+
+            it "send KEY_CODE_WITH_KEYPRESS message to keybard" do
+              expect(@keyboard).to receive(:type).with(param: "KEY_CODE_WITH_KEYPRESS", keep: "LEFTSHIFT")
+
+              @executor._execute(@event)
+            end
           end
         end
 

--- a/spec/fusuma/plugin/sendkey/keyboard_spec.rb
+++ b/spec/fusuma/plugin/sendkey/keyboard_spec.rb
@@ -192,6 +192,36 @@ module Fusuma
               @keyboard.type(param: @keys)
             end
           end
+
+          context "with keypress" do
+            context "when keypress modifier key contains a sendkey parameter" do
+              before do
+                @keypress_keys = "LEFTMETA"
+                @param_keys = "LEFTMETA+LEFT"
+              end
+
+              it "sends KEY_LEFT (without clearng or sending KEY_LEFTMETA which pressing by user)" do
+                expect(@keyboard).to receive(:clear_modifiers).with(Keyboard::MODIFIER_KEY_CODES - ["KEY_LEFTMETA"]).ordered
+                expect(@keyboard).to receive(:keydown).with("KEY_LEFT").ordered
+                expect(@keyboard).to receive(:keyup).with("KEY_LEFT").ordered
+                @keyboard.type(param: @param_keys, keep: @keypress_keys)
+              end
+            end
+
+            context "when keypress modifier key does NOT contains a sendkey parameter" do
+              before do
+                @keypress_keys = "LEFTALT"
+                @param_keys = "BRIGHTNESSUP"
+              end
+
+              it "sends KEY_BRIGHTNESSUP (and clear KEY_LEFTALT pressing by user)" do
+                expect(@keyboard).to receive(:clear_modifiers).with(array_including("KEY_LEFTALT")).ordered
+                expect(@keyboard).to receive(:keydown).with("KEY_BRIGHTNESSUP").ordered
+                expect(@keyboard).to receive(:keyup).with("KEY_BRIGHTNESSUP").ordered
+                @keyboard.type(param: @param_keys, keep: @keypress_keys)
+              end
+            end
+          end
         end
       end
     end

--- a/spec/fusuma/plugin/sendkey_spec.rb
+++ b/spec/fusuma/plugin/sendkey_spec.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-RSpec.describe Fusuma::Plugin::Sendkey do
-  it "has a version number" do
-    expect(Fusuma::Plugin::Sendkey::VERSION).not_to be nil
+module Fusuma
+  module Plugin
+    RSpec.describe Sendkey do
+      it "has a version number" do
+        expect(Fusuma::Plugin::Sendkey::VERSION).not_to be nil
+      end
+    end
   end
 end


### PR DESCRIPTION
When parent of sendkey has a keypress parameter using fusuma-plugin-sendkey , only the key except for the key of the keypress parameter is sent as sendkey. This means that sendkey and the modified key state pressed by the user work together to send the key.

Before this change, there was a bug where the modifier key would be briefly up/down during sendkey execution, and users had to exclude the keys included in keypress from the sendkey parameters. This change removes the need for that.

In keyboard.rb, the type method also adds a keep argument, which is used to exclude the modified keys specified in keep from param_keycodes by subtracting keep_keycodes from param_keycodes. This results in the remaining key codes being processed with keydown and keyup as type_keycodes.
