### PR TITLE
Send multiple keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,23 @@ NEXTSONG
 PREVIOUSSONG
 ```
 
-## Run fusuma-sendkey on Terminal
+## Running fusuma-sendkey on Terminal
 
-* `fusuma-sendkey` command is available on your terminal
+* `fusuma-sendkey` command is available on your terminal for testing.
 * `fusuma-sendkey` supports modifier keys and multiple key presses.
-Combine keys for pressing the same time with `+` 
+   - Combine keys for pressing the same time with `+` 
+   - Separate keys for pressing sequentially with `,`
 
+### Example (Sendkey with Modifier Keys)
 
 ```sh
-$ fusuma-sendkey LEFTCTRL+T # press ctrl key + t key
+$ fusuma-sendkey LEFTCTRL+T # Open a new tab
+```
+
+### Example (Sendkey with Multiple Key Presses)
+
+```sh
+$ fusuma-sendkey ["LEFTSHIFT+F10", "T", "ENTER", "ESC"] # Google Translate
 ```
 
 Some of the keys found with `fusuma-sendkey -l` may actually be invalid keys.
@@ -83,6 +91,10 @@ swipe:
       sendkey: "LEFTCTRL+T" # open new tab
     down:
       sendkey: "LEFTCTRL+W" # close tab
+
+hold:
+  3:
+    sendkey: ["LEFTSHIFT+F10", "T", "ENTER", "ESC"] # Translate in Google Chrome
 ```
 
 ### clearmodifiers

--- a/exe/fusuma-sendkey
+++ b/exe/fusuma-sendkey
@@ -36,13 +36,25 @@ if option[:version]
   return
 end
 
-param = ARGV.first
+args = ARGV.first
 
-if param.nil?
+if args.nil?
   warn 'fusuma-sendkey require 1 arugument'
   warn 'e.g. fusuma-sendkey LEFTALT+LEFT'
+  warn 'e.g. fusuma-sendkey [A, B, C]'
   exit 1
 end
 
+
+# remove [ and ] from args
+params = args.delete('[]').split(',').map(&:strip)
+require 'debug'; debugger
+
 keyboard = Fusuma::Plugin::Sendkey::Keyboard.new(name_pattern: device_name)
-keyboard.valid?(param: param) && keyboard.type(param: param)
+return unless keyboard.valid?(params)
+
+if params.size == 1
+  keyboard.type(param: params.first)
+else
+  keyboard.types(params)
+end

--- a/lib/fusuma/plugin/executors/sendkey_executor.rb
+++ b/lib/fusuma/plugin/executors/sendkey_executor.rb
@@ -26,12 +26,21 @@ module Fusuma
         # @param event [Event]
         # @return [nil]
         def execute(event)
-          MultiLogger.info(sendkey: search_param(event))
-          keyboard.type(
-            param: search_param(event),
-            keep: search_keypress(event),
-            clear: clearmodifiers(event)
-          )
+          params = search_param(event)
+          MultiLogger.info(sendkey: params)
+          case params
+          when Array
+            keyboard.types(params)
+          when String
+            keyboard.type(
+              param: params,
+              keep: search_keypress(event),
+              clear: clearmodifiers(event)
+            )
+          else
+            MultiLogger.error("sendkey: Invalid config: #{params}")
+            nil
+          end
         end
 
         # check executable
@@ -40,7 +49,7 @@ module Fusuma
         def executable?(event)
           event.tag.end_with?("_detector") &&
             event.record.type == :index &&
-            keyboard.valid?(param: search_param(event))
+            keyboard.valid?(search_param(event))
         end
 
         private

--- a/spec/fusuma/plugin/executors/sendkey_executor_spec.rb
+++ b/spec/fusuma/plugin/executors/sendkey_executor_spec.rb
@@ -25,6 +25,8 @@ module Fusuma
                       sendkey: KEY_CODE_WITH_KEYPRESS_WITH_CLEAR
                       clearmodifiers: true
 
+                direction2: { sendkey: ["LEFTSHIFT+F10", "T", "ENTER", "ESC"] }
+
             plugin:
               executors:
                 sendkey_executor:
@@ -78,15 +80,28 @@ module Fusuma
               end
             end
           end
+
+          context "with multiple keys from sendkey array" do
+            before do
+              index_with_array = Config::Index.new([:dummy, 1, :direction2])
+              record = Events::Records::IndexRecord.new(index: index_with_array)
+              @event = Events::Event.new(tag: "dummy_detector", record: record)
+            end
+
+            it "sends each key from the sendkey array to keyboard" do
+              expect(@keyboard).to receive(:types).with(["LEFTSHIFT+F10", "T", "ENTER", "ESC"])
+              subject
+            end
+          end
         end
 
         describe "#executable?" do
           before do
-            allow(@keyboard).to receive(:valid?).with(param: "MODIFIER_CODE+KEY_CODE")
+            allow(@keyboard).to receive(:valid?).with("MODIFIER_CODE+KEY_CODE")
               .and_return true
-            allow(@keyboard).to receive(:valid?).with(param: "KEY_CODE")
+            allow(@keyboard).to receive(:valid?).with("KEY_CODE")
               .and_return true
-            allow(@keyboard).to receive(:valid?).with(param: "INVALID_CODE")
+            allow(@keyboard).to receive(:valid?).with("INVALID_CODE")
               .and_return false
           end
 

--- a/spec/fusuma/plugin/sendkey/keyboard_spec.rb
+++ b/spec/fusuma/plugin/sendkey/keyboard_spec.rb
@@ -143,7 +143,6 @@ module Fusuma
 
             @device = instance_double(Sendkey::Device)
             allow(@device).to receive(:write_event).with(anything)
-            # allow(@device).to receive(:valid?).with(param: 'KEY_A')
 
             allow(Sendkey::Device).to receive(:new).and_return(@device)
 
@@ -281,6 +280,39 @@ module Fusuma
                   subject
                 end
               end
+            end
+          end
+        end
+
+        describe "#types" do
+          subject { @keyboard.types(@args) }
+          context "with multiple keys(Array)" do
+            before do
+              allow(Keyboard)
+                .to receive(:find_device)
+                .and_return(Fusuma::Device.new(name: "dummy keyboard"))
+
+              @device = instance_double(Sendkey::Device)
+              allow(@device).to receive(:write_event).with(anything)
+
+              allow(Sendkey::Device).to receive(:new).and_return(@device)
+
+              @keyboard = Keyboard.new
+              @args = ["LEFTSHIFT+F10", "T", "ENTER", "ESC"]
+            end
+
+            it "types LEFTSHIFT+F10, T, ENTER, ESC" do
+              expect(@keyboard).to receive(:send_event).with(code: "KEY_LEFTSHIFT", press: true).ordered
+              expect(@keyboard).to receive(:send_event).with(code: "KEY_F10", press: true).ordered
+              expect(@keyboard).to receive(:send_event).with(code: "KEY_F10", press: false).ordered
+              expect(@keyboard).to receive(:send_event).with(code: "KEY_LEFTSHIFT", press: false).ordered
+              expect(@keyboard).to receive(:send_event).with(code: "KEY_T", press: true).ordered
+              expect(@keyboard).to receive(:send_event).with(code: "KEY_T", press: false).ordered
+              expect(@keyboard).to receive(:send_event).with(code: "KEY_ENTER", press: true).ordered
+              expect(@keyboard).to receive(:send_event).with(code: "KEY_ENTER", press: false).ordered
+              expect(@keyboard).to receive(:send_event).with(code: "KEY_ESC", press: true).ordered
+              expect(@keyboard).to receive(:send_event).with(code: "KEY_ESC", press: false).ordered
+              subject
             end
           end
         end


### PR DESCRIPTION
Added support for sending multiple keys in an array format using sendkey.

- It is now possible to specify multiple keys in the format 
    - `$ fusuma-sendkey ["LEFTSHIFT+F10", "T", "ENTER", "ESC"]`.
- Users can customize key combinations by configuring them in the `~/.config/fusuma/config.yml` file.

```yaml
# example
hold:
  3:
    command: "fusuma-sendkey ['LEFTSHIFT+F10', 'T', 'ENTER', 'ESC']"  # Translates page in Google Chrome
```

Closes: https://github.com/iberianpig/fusuma-plugin-sendkey/issues/31, https://github.com/iberianpig/fusuma-plugin-sendkey/issues/6