### PR TITLE
Send BTN_LEFT with sendkey for mouse buttons

### DIFF
--- a/exe/fusuma-sendkey
+++ b/exe/fusuma-sendkey
@@ -1,55 +1,56 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'optparse'
-require 'fusuma/config'
-require 'fusuma/plugin/inputs/libinput_command_input.rb'
-require_relative '../lib/fusuma/plugin/sendkey/keyboard.rb'
-require_relative '../lib/fusuma/plugin/sendkey/version.rb'
+require "optparse"
+require "fusuma/config"
+require "fusuma/plugin/executors/executor"
+require "fusuma/plugin/inputs/libinput_command_input"
+require_relative "../lib/fusuma/plugin/sendkey/keyboard"
+require_relative "../lib/fusuma/plugin/executors/sendkey_executor"
+require_relative "../lib/fusuma/plugin/sendkey/version"
 
 option = {}
 opt = OptionParser.new
 
-opt.on('-l', '--list-keycodes',
-       'List available keycodes') do |v|
+opt.on("-l", "--list-keycodes",
+  "List available keycodes") do |v|
   option[:list] = v
 end
 
-opt.on('--version', 'Show version') do |v|
+opt.on("--version", "Show version") do |v|
   option[:version] = v
 end
 
 opt.parse!(ARGV)
-
-device_name = Fusuma::Config.instance.fetch_config_params(
-  :device_name,
-  Fusuma::Config::Index.new([:plugin, :executors, :sendkey_executor])
-).fetch(:device_name)
-
-if option[:list]
-  puts Fusuma::Plugin::Sendkey::Keyboard.new(name_pattern: device_name).search_codes
-  return
-end
 
 if option[:version]
   puts Fusuma::Plugin::Sendkey::VERSION
   return
 end
 
+executor_index = Fusuma::Config::Index.new([:plugin, :executors, :sendkey_executor])
+name_patterns = Fusuma::Config.instance.fetch_config_params(:device_name, executor_index).fetch(:device_name)
+
+device = Fusuma::Plugin::Sendkey::Keyboard.find_device(name_patterns: name_patterns)
+keyboard = Fusuma::Plugin::Sendkey::Keyboard.new(device: device)
+if option[:list]
+  puts keyboard.search_codes("KEY_")
+  puts keyboard.search_codes("BTN_")
+  return
+end
+
 args = ARGV.first
 
 if args.nil?
-  warn 'fusuma-sendkey require 1 arugument'
-  warn 'e.g. fusuma-sendkey LEFTALT+LEFT'
-  warn 'e.g. fusuma-sendkey [A, B, C]'
+  warn "fusuma-sendkey require 1 arugument"
+  warn "e.g. fusuma-sendkey LEFTALT+LEFT"
+  warn "e.g. fusuma-sendkey [A, B, C]"
   exit 1
 end
 
-
 # remove [ and ] from args
-params = args.delete('[]').split(',').map(&:strip)
+params = args.delete("[]").split(",").map(&:strip)
 
-keyboard = Fusuma::Plugin::Sendkey::Keyboard.new(name_pattern: device_name)
 return unless keyboard.valid?(params)
 
 if params.size == 1

--- a/exe/fusuma-sendkey
+++ b/exe/fusuma-sendkey
@@ -34,7 +34,7 @@ name_patterns = Fusuma::Config.instance.fetch_config_params(:device_name, execut
 device = Fusuma::Plugin::Sendkey::Keyboard.find_device(name_patterns: name_patterns)
 keyboard = Fusuma::Plugin::Sendkey::Keyboard.new(device: device)
 if option[:list]
-  puts keyboard.search_codes("KEY_")
+  puts keyboard.search_codes("KEY_").map { |sym| sym.to_s.delete_prefix("KEY_") }
   puts keyboard.search_codes("BTN_")
   return
 end

--- a/lib/fusuma/plugin/executors/sendkey_executor.rb
+++ b/lib/fusuma/plugin/executors/sendkey_executor.rb
@@ -55,7 +55,10 @@ module Fusuma
         private
 
         def keyboard
-          @keyboard ||= Sendkey::Keyboard.new(name_pattern: @device_name)
+          @keyboard ||= begin
+            device = Sendkey::Keyboard.find_device(name_patterns: @device_name)
+            Sendkey::Keyboard.new(device: device)
+          end
         end
 
         def search_param(event)

--- a/lib/fusuma/plugin/sendkey/device.rb
+++ b/lib/fusuma/plugin/sendkey/device.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "revdev"
+require "set"
+
 module Fusuma
   module Plugin
     module Sendkey
@@ -7,7 +10,10 @@ module Fusuma
       class Device
         def initialize(path:)
           @evdev = Revdev::EventDevice.new(path)
+          @capabilities = Set.new
         end
+
+        attr_reader :capabilities
 
         def path
           raise "Device path is not found" if @evdev.nil?
@@ -17,6 +23,31 @@ module Fusuma
 
         def write_event(event)
           @evdev.write_input_event(event)
+        end
+
+        def reload_capability
+          @capabilities.clear
+
+          buf = fetch_capabilities
+          buf.unpack("C*").each_with_index do |byte, i|
+            8.times do |bit| # 0..7
+              if byte[bit] != 0
+                @capabilities << (i * 8 + bit)
+              end
+            end
+          end
+          @capabilities
+        end
+
+        private
+
+        EVIOCGBIT = 2153792801
+
+        def fetch_capabilities
+          file = File.open(path, "r")
+          buf = +"" # unfreeze string
+          file.ioctl(EVIOCGBIT, buf)
+          buf
         end
       end
     end

--- a/spec/fusuma/plugin/sendkey/device_spec.rb
+++ b/spec/fusuma/plugin/sendkey/device_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "./lib/fusuma/plugin/sendkey/device"
+
+module Fusuma
+  module Plugin
+    module Sendkey
+      RSpec.describe Device do
+        let(:mock_evdev) { instance_double("Revdev::EventDevice") }
+        let(:mock_file) { instance_double("File") }
+        let(:device_path) { "/dev/input/event0" }
+        let(:device) { Device.new(path: device_path) }
+        let(:mock_capabilities) {
+          [254, 255, 255, 255, 255, 255, 255, 255, 255, 255, 239, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 7, 255, 255, 255, 255, 255, 255, 0, 255, 3, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 7, 15, 0, 255, 255, 31, 0, 254, 7, 255, 15, 255, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0].pack("C*")
+        }
+
+        before do
+          allow(Revdev::EventDevice).to receive(:new).with(device_path).and_return(mock_evdev)
+          allow(mock_evdev).to receive(:file).and_return(mock_file)
+        end
+
+        describe "#path" do
+          it "returns the device path" do
+            allow(mock_file).to receive(:path).and_return(device_path)
+            expect(device.path).to eq(device_path)
+          end
+
+          it "raises an error if the evdev is nil" do
+            allow(mock_evdev).to receive(:nil?).and_return(true)
+            expect { device.path }.to raise_error("Device path is not found")
+          end
+        end
+
+        describe "#write_event" do
+          it "writes an input event to the evdev device" do
+            event = double("event")
+            expect(mock_evdev).to receive(:write_input_event).with(event)
+            device.write_event(event)
+          end
+        end
+
+        describe "#reload_capability" do
+          it "reloads the capabilities from the evdev device" do
+            allow(device).to receive(:fetch_capabilities).and_return(mock_capabilities)
+
+            expect(device.reload_capability).to be_a(Set)
+            expect(device.reload_capability).to be_include(Revdev::KEY_ESC)       # 1
+            expect(device.reload_capability).to be_include(Revdev::KEY_1)         # 2
+            expect(device.reload_capability).to be_include(Revdev::KEY_A)         # 30
+            expect(device.reload_capability).to be_include(Revdev::KEY_LEFTSHIFT) # 42
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Overview
This pull request adds mouse button operations to the `sendkey` command. With this change, operating mouse buttons will be similar to operating keyboard keys.

#### Details of Changes
- Mouse button operations (e.g., `BTN_LEFT`, `BTN_RIGHT`, `BTN_MIDDLE`) have been added to `fusuma-sendkey`.
- The functionalities in the `Keyboard` class have been extended to handle mouse button operations.
- Test cases for keyboard and mouse button operations have been added.

#### Notes
- Mouse button operations are available only when mouse buttons are implemented on the keyboard.
- Available mouse buttons can be checked with the command `fusuma-sendkey -l | grep BTN_`.
- A virtual keyboard using uinput (e.g., [fusuma-plugin-remap](https://github.com/iberianpig/fusuma-plugin-remap)) will likely be needed.

#### Usage Example

It is important to note that you need to specify the mouse button with the prefix `BTN_` as shown below.

```yaml
---
context:
  thumbsense: true

remap:
  F: BTN_LEFT # <- remaps to left click using fusuma-plugin-remap
              # fusuma-plugin-remap already supports mouse button operations.

  E: 
    sendkey: LEFTCTRL+BTN_LEFT # <- sends left click with left control key using fusuma-plugin-sendkey
                               # This PR adds mouse button operations to the `sendkey` command.
```

In command line, following command can be executed to test the feature.
```bash
$ fusuma-sendkey BTN_RIGHT
```
